### PR TITLE
Overleaf 中华文中宋字体出错

### DIFF
--- a/xdupgtp.cls
+++ b/xdupgtp.cls
@@ -176,7 +176,7 @@
   % 定义黑体字体
   \newCJKfontfamily\heiti{simhei.ttf}[Path=fonts/,BoldFont={simhei.ttf},BoldFeatures={FakeBold=\FakeBoldValue}]
   % 定义华文中宋字体
-  \newCJKfontfamily\stzhongsong{STZHONGS.TTF}[BoldFont={STZHONGS.TTF},BoldFeatures={FakeBold=\FakeBoldValue}]
+  \newCJKfontfamily\stzhongsong{STZHONGS.TTF}[Path=fonts/,BoldFont={STZHONGS.TTF},BoldFeatures={FakeBold=\FakeBoldValue}]
 \else
   % 配置默认英文字体
   \setmainfont{Times New Roman}


### PR DESCRIPTION
`xdupgtp.cls` 文件中的 Overleaf 分支中，华文中宋字体的定义缺失了 `Path` 的配置（其他字体都有，应该是写漏了），导致 Overleaf 编译报错：
<img width="737" alt="错误截图" src="https://user-images.githubusercontent.com/31400828/148985132-97488ed1-5f13-4d19-a3e4-2196c3e4108d.png">